### PR TITLE
1.0.6

### DIFF
--- a/qingwa-torrent-assistant.js
+++ b/qingwa-torrent-assistant.js
@@ -4,8 +4,8 @@
 // @version      1.0.6
 // @description  不可蛙-审种助手
 // @author       qingwa.pro@jaycode
-// @match        *://new.qingwa.pro/details.php*
-// @icon         https://new.qingwa.pro/favicon.ico
+// @match        *://qingwapt.com/details.php*
+// @icon         https://qingwapt.com/favicon.ico
 // @require      https://cdn.bootcss.com/jquery/3.4.1/jquery.min.js
 // @grant        GM_setValue
 // @grant        GM_getValue
@@ -379,7 +379,7 @@
     var isDV = false;
     var isHDR = false;
     var isHDR10P = false;
-    var isDIY = title.match(/(BHYS|sGnb|D[Ii]Y)@/);
+    var isDIY = title.match(/(BHYS|sGnb|SPM|D[Ii]Y)@/);
 
     var tdlist = $('#outer').find('td');
     for (var i = 0; i < tdlist.length; i ++) {


### PR DESCRIPTION
检测关于Blu-ray/BluRay的错误写法
修复未正确提取基本信息中视频编码的Bug
修正国语检测逻辑
修复中字标签和VCB标签检测结果无法呈现的Bug
启用更多警告
检测标题中的10bit
增加音频编码OPUS
增加标题中分辨率，来源，媒介的检测
增加标题中HDR类型，视频编码，音频编码的检测
检查Mediainfo栏的填写内容是否符合要求
检测DIY/原生原盘标签
更换域名